### PR TITLE
Write test for mode-routing directive

### DIFF
--- a/src/app/presentation/mode-routing/mode-routing.directive.spec.ts
+++ b/src/app/presentation/mode-routing/mode-routing.directive.spec.ts
@@ -1,9 +1,69 @@
+import { Component, HostListener, Output, EventEmitter, DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ModeRoutingDirective } from './mode-routing.directive';
+import { Mode } from './../mode.enum';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-test-component',
+  template: '<div app-mode-routing></div>'
+})
+class TestComponent {
+  @Output() onModeChange: EventEmitter<Mode> = new EventEmitter();
+}
 
 describe('ModeRoutingDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  let directiveEl: DebugElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        TestComponent,
+        ModeRoutingDirective
+      ],
+      imports: [
+        RouterTestingModule
+      ]
+    }).compileComponents();
+  }));
+
+  beforeEach(async(() => {
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+    directiveEl = fixture.debugElement.query(By.directive(ModeRoutingDirective));
+  }));
+
   it('should create an instance', () => {
-    // TODO: Write this test.
-    // const directive = new ModeRoutingDirective();
-    // expect(directive).toBeTruthy();
+    expect(directiveEl).not.toBeNull();
+    expect(directiveEl).toBeDefined();
   });
+
+  it('should set queryParams onModeChange event of overview', inject([Router], (router: Router) => {
+    const MODE: Mode = 'overview';
+    const componentInstance = fixture.componentInstance;
+
+    const spy = spyOn(router, 'navigate');
+
+    directiveEl.triggerEventHandler('onModeChange', MODE);
+    fixture.detectChanges();
+
+    expect(router.navigate).toHaveBeenCalled();
+    expect(spy.calls.first().args[1].queryParams.mode).toBe(MODE);
+  }));
+
+  it('should not set queryParams onModeChange event of none', inject([Router], (router: Router) => {
+    const MODE: Mode = 'none';
+    const componentInstance = fixture.componentInstance;
+
+    const spy = spyOn(router, 'navigate');
+
+    directiveEl.triggerEventHandler('onModeChange', MODE);
+    fixture.detectChanges();
+
+    expect(router.navigate).toHaveBeenCalled();
+    expect(spy.calls.first().args[1].queryParams).toBeUndefined();
+  }));
 });

--- a/src/app/presentation/mode-routing/mode-routing.directive.spec.ts
+++ b/src/app/presentation/mode-routing/mode-routing.directive.spec.ts
@@ -2,17 +2,17 @@ import { Component, HostListener, Output, EventEmitter, DebugElement } from '@an
 import { By } from '@angular/platform-browser';
 import { async, ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { Router } from '@angular/router';
+
 import { ModeRoutingDirective } from './mode-routing.directive';
 import { Mode } from './../mode.enum';
-import { Router } from '@angular/router';
+
 
 @Component({
   selector: 'app-test-component',
   template: '<div app-mode-routing></div>'
 })
-class TestComponent {
-  @Output() onModeChange: EventEmitter<Mode> = new EventEmitter();
-}
+class TestComponent {}
 
 describe('ModeRoutingDirective', () => {
   let fixture: ComponentFixture<TestComponent>;

--- a/src/app/presentation/mode-routing/mode-routing.directive.ts
+++ b/src/app/presentation/mode-routing/mode-routing.directive.ts
@@ -1,32 +1,23 @@
 import { ActivatedRoute, Router } from '@angular/router';
-import { Directive, HostListener, OnInit } from '@angular/core';
+import { Directive, HostListener, Input } from '@angular/core';
 import { Mode } from './../mode.enum';
-import { PresentationComponent } from './../presentation/presentation.component';
 
 @Directive({
   // tslint:disable-next-line:all TODO: Fix linter warnings on the selector and delete this comment.
   selector: '[app-mode-routing]'
 })
-export class ModeRoutingDirective implements OnInit {
+export class ModeRoutingDirective {
+  constructor(private router: Router, private route: ActivatedRoute) {}
 
-  constructor(private router: Router,
-              private route: ActivatedRoute,
-              private presentation: PresentationComponent) { }
-
-  ngOnInit() {
-    // Initialize mode based on url on load
-    if (!!this.route.snapshot.queryParams['mode']) {
-      this.presentation.mode = this.route.snapshot.queryParams['mode'];
-    }
-  }
   // Update url based on mode
   @HostListener('onModeChange', ['$event']) modeChange(mode: Mode) {
     let queryParams;
+
     if (mode !== Mode.none) {
       queryParams = {mode};
     }
-    this.router.navigate([],
-    {
+
+    this.router.navigate([], {
        relativeTo: this.route,
        queryParams
     });

--- a/src/app/presentation/presentation/presentation.component.ts
+++ b/src/app/presentation/presentation/presentation.component.ts
@@ -2,8 +2,11 @@ import {
   Component,
   EventEmitter,
   Input,
-  Output
-  } from '@angular/core';
+  OnInit,
+  Output,
+  HostListener
+} from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Mode } from './../mode.enum';
 import { SlideComponent } from './../slide/slide.component';
 import { Subscription } from 'rxjs/Subscription';
@@ -18,7 +21,7 @@ export interface SlideConfig {
   templateUrl: './presentation.component.html',
   styleUrls: ['./presentation.component.css']
 })
-export class PresentationComponent  {
+export class PresentationComponent implements OnInit {
   private generatedSlideIndex = 0;
   private activeMode: Mode = Mode.none;
 
@@ -33,6 +36,14 @@ export class PresentationComponent  {
   areShortcutsEnabled = true;
   // Expose enum to template
   modeEnum = Mode;
+
+  constructor(private route: ActivatedRoute) {}
+
+  ngOnInit() {
+    if (!!this.route.snapshot.queryParams['mode']) {
+      this.mode = this.route.snapshot.queryParams['mode'];
+    }
+  }
 
   get mode(): Mode {
     return this.activeMode;


### PR DESCRIPTION
Do not merge until #90 is merged. (Otherwise this test will not run against travis).

I refactored the logic because the child directive was setting a property on another component `onInit`. It only made sense for the parent component to set the property itself since the child directive wasn't doing any unique or complicated logic. 