### PR TITLE
hides ripples animation in overview mode.

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -85,6 +85,10 @@ h1, h2, h3, li {
   visibility: hidden;
 }
 
+.presentation.overview app-ripple-animation {
+  visibility: hidden;
+}
+
 .presentation.overview .slide {
   pointer-events: none;
   margin: 2% auto;


### PR DESCRIPTION
just a simple css fix for hiding ripple animation in overview mode.  