### PR TITLE
fix VSC links

### DIFF
--- a/src/app/demo/visual-studio-code/visual-studio-code.component.html
+++ b/src/app/demo/visual-studio-code/visual-studio-code.component.html
@@ -67,7 +67,7 @@
         <h2>Interested? Curious?</h2>
         <h2>Ready to join the cult?</h2>
         <ol>
-          <li>Click <a href="">here</a> to download.</li>
+          <li>Click <a href="https://code.visualstudio.com/" target="_blank">here</a> to download.</li>
           <li>Run the installer</li>
           <li>Enjoy!</li>
           <li>Profit???</li>
@@ -87,21 +87,21 @@
         <li>There are many extensions available for VSCode. Some good ones include:
           <ul>
             <li>
-              <a href="https://marketplace.visualstudio.com/itms?itemName=robertohuertasm.vscode-icons">vscode-icons</a> - Adds icons to your file tree (ohhhh shiny)</li>
+              <a href="https://marketplace.visualstudio.com/items?itemName=robertohuertasm.vscode-icons" target="_blank">vscode-icons</a> - Adds icons to your file tree (ohhhh shiny)</li>
             <li>
-              <a href="https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig">Editor Config</a> - Editor Config Plugin for vs code
+              <a href="https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig" target="_blank">Editor Config</a> - Editor Config Plugin for vs code
             </li>
             <li>
-              <a href="https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint">ESLint</a> - JS linter plugin
+              <a href="https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint" target="_blank">ESLint</a> - JS linter plugin
             </li>
             <li>
-              <a href="https://marketplace.visualstudio.com/items?itemName=eg2.tslint">TSLint</a> - TypeScript linter plugin (Moarrrrr linter)
+              <a href="https://marketplace.visualstudio.com/items?itemName=eg2.tslint" target="_blank">TSLint</a> - TypeScript linter plugin (Moarrrrr linter)
             </li>
             <li>
-              <a href="https://marketplace.visualstudio.com/items?itemName=HookyQR.beautify">Beautify</a> - Beautify code, if you don't like JS-beautify
+              <a href="https://marketplace.visualstudio.com/items?itemName=HookyQR.beautify" target="_blank">Beautify</a> - Beautify code, if you don't like JS-beautify
             </li>
             <li>
-              And many many more! check out the <a href="https://marketplace.visualstudio.com/VSCode">offical site</a> and <a href="https://github.com/viatsko/awesome-vscode">Awesome VS Code</a> for more!
+              And many many more! check out the <a href="https://marketplace.visualstudio.com/VSCode" target="_blank">offical site</a> and <a href="https://github.com/viatsko/awesome-vscode" target="_blank">Awesome VS Code</a> for more!
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Fixed links on the Visual Studio Code (optional) info pages. 