### PR TITLE
add import statement linter error if no spaces

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -94,6 +94,7 @@
       true,
       "check-branch",
       "check-decl",
+      "check-module",
       "check-operator",
       "check-separator",
       "check-type"

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
     "forin": true,
     "import-blacklist": [true, "rxjs"],
     "import-spacing": true,
+    "import-destructuring-spacing": true,
     "indent": [
       true,
       "spaces"


### PR DESCRIPTION
as per angular convention https://github.com/mgechev/codelyzer/issues/40
causes `ng lint` to show error if no space around curly braces

TODO: add spaces to all import statements